### PR TITLE
Add function to capture logs

### DIFF
--- a/test/System/Logging/FacadeSpec.hs
+++ b/test/System/Logging/FacadeSpec.hs
@@ -5,18 +5,34 @@ import           Data.IORef
 
 import           System.Logging.Facade.Types
 import           System.Logging.Facade.Sink
-import           System.Logging.Facade
+import           System.Logging.Facade as Log
 
 main :: IO ()
 main = hspec spec
 
 spec :: Spec
 spec = do
+  let logToIORef :: IORef [LogRecord] -> LogSink
+      logToIORef ref record = modifyIORef ref (record :)
+
   describe "info" $ do
     it "writes a log message with log level INFO" $ do
       ref <- newIORef []
-      let captureLogMessage :: LogSink
-          captureLogMessage record = modifyIORef ref (record :)
-      setLogSink captureLogMessage
+      setLogSink $ logToIORef ref
       info "some log message"
       readIORef ref `shouldReturn` [LogRecord INFO Nothing "some log message"]
+
+  describe "captureLogs" $ do
+    it "returns all logs of an action" $ do
+      (logs, ()) <- captureLogs $ do
+        Log.trace "this should be captured"
+        Log.trace "this should be captured next"
+      logs `shouldBe` [ LogRecord TRACE Nothing "this should be captured"
+                      , LogRecord TRACE Nothing "this should be captured next"
+                      ]
+
+    it "prevents logs from going to the log sink" $ do
+      ref <- newIORef []
+      setLogSink $ logToIORef ref
+      _ <- captureLogs $ Log.trace "this should be captured"
+      readIORef ref `shouldReturn` []


### PR DESCRIPTION
This adds a `captureLogs` function that may be used to get (and prevent from being output to the default log sink) all logs from an IO action.