### PR TITLE
compatibility with ghc-8 (wip)

### DIFF
--- a/src/System/Logging/Facade.hs
+++ b/src/System/Logging/Facade.hs
@@ -27,7 +27,9 @@ import           System.Logging.Facade.Types
 import           System.Logging.Facade.Class
 
 #ifdef HAS_SOURCE_LOCATIONS
+#if ! MIN_VERSION_base(4,9,0)
 import           GHC.SrcLoc
+#endif
 import           GHC.Stack
 #define with_loc (?loc :: CallStack) =>
 #else


### PR DESCRIPTION
I haven't really looked into why `GHC.SrcLoc` has vanished, but this seems to be needed to make this work with `ghc-8` (`rc-2`).

I'd like to add a test for source locations in log messages and enable that test-case with `CPP` and `HAS_SOURCE_LOCATIONS`.

And I don't want to add travis tests for `ghc-8`, just because I expect that to be complicated to set up.

@sol: Are you okay with that?