### PR TITLE
Set default buffering for defaultLogSink to LineBuffering

### DIFF
--- a/src/System/Logging/Facade/Sink.hs
+++ b/src/System/Logging/Facade/Sink.hs
@@ -20,8 +20,12 @@ type LogSink = LogRecord -> IO ()
 
 -- use the unsafePerformIO hack to share one sink across a process
 logSink :: IORef LogSink
-logSink = unsafePerformIO (defaultLogSink >>= newIORef)
 {-# NOINLINE logSink #-}
+logSink = unsafePerformIO action
+  where
+    action = do
+      hSetBuffering stderr LineBuffering
+      defaultLogSink >>= newIORef
 
 -- | Return the global log sink.
 getLogSink :: IO LogSink


### PR DESCRIPTION
Since the default buffering for `stderr` is `NoBuffering`, a system call occurs for every character, causing a significant loss in speed (see code below). As long as `logging-facade` is using `hPutStrLn` I believe it's safe to set the buffer mode to `LineBuffering` (for the default `logSink`). This would obtain a significant speed increase when performing I/O, without losing any log messages (since `/n` would be appended on every call to `hPutStrLn` (see `writeBlocks` function).

``` haskell
-- | The same as 'hPutStr', but adds a newline character.
hPutStrLn :: Handle -> String -> IO ()
hPutStrLn handle str = hPutStr' handle str True
  -- An optimisation: we treat hPutStrLn specially, to avoid the
  -- overhead of a single putChar '\n', which is quite high now that we
  -- have to encode eagerly.

hPutStr' :: Handle -> String -> Bool -> IO ()
hPutStr' handle str add_nl =
  do
    (buffer_mode, nl) <-
         wantWritableHandle "hPutStr" handle $ \h_ -> do
                       bmode <- getSpareBuffer h_
                       return (bmode, haOutputNL h_)

    case buffer_mode of
       (NoBuffering, _) -> do
            hPutChars handle str        -- v. slow, but we don't care
            when add_nl $ hPutChar handle '\n'
       (LineBuffering, buf) -> do
            writeBlocks handle True  add_nl nl buf str
       (BlockBuffering _, buf) -> do
            writeBlocks handle False add_nl nl buf str

hPutChars :: Handle -> [Char] -> IO ()
hPutChars _      [] = return ()
hPutChars handle (c:cs) = hPutChar handle c >> hPutChars handle cs
```

<img width="935" alt="screen shot 2016-06-08 at 12 38 56 pm" src="https://cloud.githubusercontent.com/assets/875324/15904511/f592c634-2d76-11e6-9da5-9e746ac181d3.png">
