### PR TITLE
Use base-compat to add support for all versions of GHC 7.x and later.

### DIFF
--- a/logging-facade.cabal
+++ b/logging-facade.cabal
@@ -1,4 +1,4 @@
--- This file has been generated from package.yaml by hpack version 0.11.2.
+-- This file has been generated from package.yaml by hpack version 0.17.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -10,6 +10,7 @@ homepage:         https://github.com/sol/logging-facade#readme
 bug-reports:      https://github.com/sol/logging-facade/issues
 license:          MIT
 license-file:     LICENSE
+tested-with:      GHC > 7.4 && < 8.1
 copyright:        (c) 2014-2016 Simon Hengel
 author:           Simon Hengel <sol@typeful.net>
 maintainer:       Simon Hengel <sol@typeful.net>
@@ -33,6 +34,7 @@ library
   build-depends:
       base == 4.*
     , transformers
+    , base-compat > 0.9
   default-language: Haskell2010
 
 test-suite spec

--- a/package.yaml
+++ b/package.yaml
@@ -8,6 +8,7 @@ copyright:        (c) 2014-2016 Simon Hengel
 author:           Simon Hengel <sol@typeful.net>
 maintainer:       Simon Hengel <sol@typeful.net>
 category:         System
+tested-with:      GHC > 7 && < 8.1
 
 github: sol/logging-facade
 
@@ -18,6 +19,7 @@ library:
   dependencies:
     - base == 4.*
     - transformers
+    - base-compat > 0.9
 
 tests:
   spec:

--- a/src/System/Logging/Facade/Sink.hs
+++ b/src/System/Logging/Facade/Sink.hs
@@ -8,7 +8,7 @@ module System.Logging.Facade.Sink (
 ) where
 
 import           Control.Concurrent
-import           Data.IORef
+import           Data.IORef.Compat
 import           System.IO
 import           System.IO.Unsafe (unsafePerformIO)
 import           Control.Exception


### PR DESCRIPTION
Fixes https://github.com/sol/logging-facade/issues/14.